### PR TITLE
Remove deprecated `Ember.required` usage.

### DIFF
--- a/addon/mixins/autoresize.js
+++ b/addon/mixins/autoresize.js
@@ -120,7 +120,7 @@ var AutoResize = Ember.Mixin.create(/** @scope AutoResize.prototype */{
     @required
     @type String
    */
-  autoResizeText: Ember.required(),
+  autoResizeText: null,
 
   /**
     Whether the autoResizeText has been sanitized


### PR DESCRIPTION
`Ember.required` hasn't really worked properly, and was deprecated in https://github.com/emberjs/ember.js/pull/10668.