### PR TITLE
allow textfield to accommodate placeholders

### DIFF
--- a/addon/ext/text-field.js
+++ b/addon/ext/text-field.js
@@ -35,12 +35,22 @@ Ember.TextField.reopen(AutoResize, /** @scope Ember.TextField.prototype */{
     so users can click into an empty
     text field without it being too small
 
+    If a placeholder is set,
+    it will be used instead.
+
     @property autoResizeText
     @type String
    */
-  autoResizeText: Ember.computed('value', function () {
-    var value = get(this, 'value');
-    return isEmpty(value) ? '.' : value;
-  })
+  autoResizeText: Ember.computed('value', 'placeholder',
+    function () {
+      var placeholder = get(this, 'placeholder');
+      var value = get(this, 'value');
 
+      if(isEmpty(value)){
+        return isEmpty(placeholder) ? '.' : placeholder;
+      }
+
+      return value;
+    }
+  )
 });


### PR DESCRIPTION
This addresses issue #22. 

When there is no value, the textfield will use the placeholder value, if one has been set, to determine size. Otherwise, the placeholder is awkwardly cut off when there is no value.